### PR TITLE
feat: button tooltips, fix count & misc

### DIFF
--- a/src/lib/components/navbar.svelte
+++ b/src/lib/components/navbar.svelte
@@ -8,6 +8,7 @@
 	import iflog from 'iflog';
 
 	let stars = $state(0);
+	/** @type {ReturnType<typeof setInterval>} */
 	let interval;
 
 	onMount(async () => {
@@ -16,9 +17,10 @@
 			if (!res.ok) {
 				throw new Error(`GitHub API error: ${res.status}`);
 			}
+			/** @type {{ stargazers_count?: number }} */
 			const data = await res.json();
 
-			const targetStars = data.stargazers_count || 0;
+			const targetStars = data.stargazers_count ?? 0;
 			if (targetStars === 0) return;
 
 			const maxIncrement = Math.max(5, Math.ceil(targetStars / 30));
@@ -42,11 +44,7 @@
 		}
 	});
 
-	onDestroy(() => {
-		if (interval) {
-			clearInterval(interval);
-		}
-	});
+	onDestroy(() => clearInterval(interval));
 </script>
 
 <header

--- a/src/lib/icons/index.js
+++ b/src/lib/icons/index.js
@@ -510,7 +510,7 @@ import wineOff from './wine-off.svelte';
 import x from './x.svelte';
 import zapOff from './zap-off.svelte';
 
-let ICONS_LIST = [
+const ICONS_LIST = [
 	{
 		name: 'accessibility',
 		icon: accessibility,

--- a/src/lib/utils/debounce.js
+++ b/src/lib/utils/debounce.js
@@ -1,11 +1,13 @@
 /**
  * Creates a debounced version of a function that delays its execution
  * until after a specified delay has elapsed since the last time it was invoked.
- * @param {Function} fn - The function to debounce
+ * @template {(...args: unknown[]) => unknown} T
+ * @param {T} fn - The function to debounce
  * @param {number} delay - The delay in milliseconds
- * @returns {Function} The debounced function
+ * @returns {T} The debounced function
  */
 export function debounce(fn, delay) {
+	/** @type {ReturnType<typeof setTimeout>} */
 	let timeoutId;
 
 	return function (...args) {

--- a/src/lib/utils/icons.js
+++ b/src/lib/utils/icons.js
@@ -1,6 +1,12 @@
 import iflog from 'iflog';
 
-export let getIconSource = async (iconName) => {
+/** @import ICONS_LIST from '$lib/icons/index.js' */
+
+/**
+ * @param {typeof ICONS_LIST[number]} iconName 
+ * @returns {Promise<typeof ICONS_LIST[number] & { source: string }>} 
+ */
+export const getIconSource = async (iconName) => {
 	try {
 		// Create a map of all icon files at build time
 		const iconModules = import.meta.glob('/src/lib/icons/*.svelte', {
@@ -22,7 +28,12 @@ export let getIconSource = async (iconName) => {
 	}
 };
 
-export let preloadIconSources = async (icons) => {
+
+/**
+ * @param {typeof ICONS_LIST} icons
+ * @returns {Promise<(typeof ICONS_LIST[number] & { source?: string })[]>}
+ */
+export const preloadIconSources = async (icons) => {
 	try {
 		// Create a map of all icon files at build time
 		const iconModules = import.meta.glob('/src/lib/icons/*.svelte', {
@@ -49,7 +60,10 @@ export let preloadIconSources = async (icons) => {
 	}
 };
 
-export let downloadIcon = async (icon) => {
+/**
+ * @param {typeof ICONS_LIST[number] & { source?: string }} icon 
+ */
+export const downloadIcon = async (icon) => {
 	try {
 		if (!icon.source) {
 			// Fetch the source if not already loaded


### PR DESCRIPTION
Hi, thank you for creating such a great project! I stumbled upon it from https://github.com/pqoqubbw/icons right when I thought it was yet another dead end because React-only. Glad this Svelte version exists!

I experienced tiny inconveniences while browsing your site, so here are a few improvements:
- **Incorrect count in the search bar**. The number of components available is incorrect for a few milliseconds when clearing the search bar after having typed something. It's now fixed by using the total count, not the filtered one.

  | <img src="https://github.com/user-attachments/assets/31e58edd-d347-4198-b802-91ace3b4b0d2" alt="before" width="300" /> | <img src="https://github.com/user-attachments/assets/6b890f64-5a4a-41a4-8b46-245d811e1c19" alt="after" width="300" /> |
  | :---: | :---: |
  | Before | After |

- **Missing tooltips on buttons**. This one is an inconvenience more than a bug: we're not really sure what the buttons on each component do. Does the copy button copy the name? The contents? A URL? Same question for the others. I've added shadcn tooltips with a reduced delay and a preferred side to fix that.

  |  <img src="https://github.com/user-attachments/assets/699474c3-191d-4855-9341-37289115ae2a" alt="tooltips" width="400" /> |
  | :---: |
  | The tooltips (`bits-ui` has some difficulties with really close tooltips, but that's better than nothing!) |

- Misc code improvements. I added types using JSDoc (as your codebase doesn't use TypeScript), tweaked a few things here and there. Hope it fits your liking!
  - Remove the useless check for an existing interval before passing the value to `clearInterval`, as it natively supports `undefined` intervals
  - `const`ify variables
  - Use `$state` for `icons`, otherwise it wouldn't work now that it's used inside the search bar
  - Use the [`{:else}` block](https://svelte.dev/docs/svelte/each#Else-blocks) of `{#each}` instead of using a special branch for it; adjust the CSS accordingly
  - Use `size-X` in Tailwind instead of `h-X w-X` (exists since Tailwind [3.4.0](https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.4.0))