### PR TITLE
fix: fix overlaying tooltips

### DIFF
--- a/src/routes/icons/+page.svelte
+++ b/src/routes/icons/+page.svelte
@@ -231,8 +231,8 @@
 							/>
 							<p class="text-muted-foreground mt-5 mb-3 text-center text-xs">{icon.name}</p>
 							<div class="flex items-center justify-center gap-2">
-								<Tooltip.Provider>
-									<Tooltip.Root delayDuration={300}>
+								<Tooltip.Provider delayDuration={300}>
+									<Tooltip.Root>
 										<Tooltip.Trigger>
 											{#snippet child({ props })}
 												<Button
@@ -255,10 +255,8 @@
 										</Tooltip.Trigger>
 										<Tooltip.Content side="bottom">Copy Svelte component</Tooltip.Content>
 									</Tooltip.Root>
-								</Tooltip.Provider>
 
-								<Tooltip.Provider>
-									<Tooltip.Root delayDuration={300}>
+									<Tooltip.Root>
 										<Tooltip.Trigger>
 											{#snippet child({ props })}
 												<Button
@@ -281,22 +279,26 @@
 										</Tooltip.Trigger>
 										<Tooltip.Content side="bottom">Download Svelte component</Tooltip.Content>
 									</Tooltip.Root>
-								</Tooltip.Provider>
 
-								{#if false}
-									<Button
-										href={'https://github.com/jis3r/icons/blob/master/src/lib/icons/' +
-											icon.name +
-											'.svelte'}
-										variant="ghost"
-										class="hover:bg-accent size-8 rounded-md p-2 transition-colors duration-200"
-									>
-										<ExternalLink class="size-4" />
-									</Button>
-								{/if}
+									{#if false}
+										<Tooltip.Root>
+											<Tooltip.Trigger>
+												{#snippet child({ props })}
+													<Button
+														{...props}
+														href="https://github.com/jis3r/icons/blob/master/src/lib/icons/{icon.name}.svelte"
+														variant="ghost"
+														class="hover:bg-accent size-8 rounded-md p-2 transition-colors duration-200"
+													>
+														<ExternalLink class="size-4" />
+													</Button>
+												{/snippet}
+											</Tooltip.Trigger>
+											<Tooltip.Content side="bottom">Open icon source on GitHub</Tooltip.Content>
+										</Tooltip.Root>
+									{/if}
 
-								<Tooltip.Provider>
-									<Tooltip.Root delayDuration={300}>
+									<Tooltip.Root>
 										<Tooltip.Trigger>
 											{#snippet child({ props })}
 												<Button


### PR DESCRIPTION
Follow-up of #40

I discovered the source of the overlaying problem with the tooltips I mentioned in my previous PR: tooltips on a shared area should use a single provider.

| <img src="https://github.com/user-attachments/assets/01b05ce8-3923-41c2-8fb6-ff06ea66a6c3" alt="before" width="300" /> |  <img src="https://github.com/user-attachments/assets/f55d127c-b39d-4260-8195-a78d9aba37c2" alt="after" width="300" /> |
| :---: | :---: |
| Before | After |

So, here's the fix for my own mess ^^

> [!NOTE]
> I also added the tooltip wrapper for the disabled button so it's usable out-of-the-box the day it's re-enabled