### PR TITLE
build(deps): npm audit fix and approve install scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -867,268 +867,6 @@
 				"svelte": "^4 || ^5"
 			}
 		},
-		"node_modules/@opentelemetry/api": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/@opentelemetry/api-logs": {
-			"version": "0.208.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
-			"integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/@opentelemetry/core": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
-			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-logs-otlp-http": {
-			"version": "0.208.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
-			"integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/api-logs": "0.208.0",
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/otlp-exporter-base": "0.208.0",
-				"@opentelemetry/otlp-transformer": "0.208.0",
-				"@opentelemetry/sdk-logs": "0.208.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/otlp-exporter-base": {
-			"version": "0.208.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
-			"integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/otlp-transformer": "0.208.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/otlp-transformer": {
-			"version": "0.208.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
-			"integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/api-logs": "0.208.0",
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/resources": "2.2.0",
-				"@opentelemetry/sdk-logs": "0.208.0",
-				"@opentelemetry/sdk-metrics": "2.2.0",
-				"@opentelemetry/sdk-trace-base": "2.2.0",
-				"protobufjs": "^7.3.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
-			"integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/resources": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.0.tgz",
-			"integrity": "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.5.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
-			"integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-logs": {
-			"version": "0.208.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
-			"integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/api-logs": "0.208.0",
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/resources": "2.2.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.4.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
-			"integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-metrics": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
-			"integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/resources": "2.2.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.9.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
-			"integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
-			"integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/resources": "2.2.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
-			"integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
-			"integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
-			}
-		},
 		"node_modules/@oxc-project/types": {
 			"version": "0.133.0",
 			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
@@ -1147,95 +885,21 @@
 			"license": "MIT"
 		},
 		"node_modules/@posthog/core": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.20.1.tgz",
-			"integrity": "sha512-uoTmWkYCtLYFpiK37/JCq+BuCA/OZn1qQZn5cPv1EEKt3ni3Zgg48xWCnSEyGFl5KKSXlfCruiRTwnbAtCgrBA==",
+			"version": "1.40.1",
+			"resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.40.1.tgz",
+			"integrity": "sha512-jXuMtZCwA7AMpYlo1wjm6GlC58YBlz/ZxpDIsF9hroUfqYoPPDmQbsQb4iiZAS43+o/kwloxdKJIlE0IiwQ5HQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cross-spawn": "^7.0.6"
+				"@posthog/types": "^1.393.0"
 			}
 		},
 		"node_modules/@posthog/types": {
-			"version": "1.342.1",
-			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.342.1.tgz",
-			"integrity": "sha512-bcyBdO88FWTkd5AVTa4Nu8T7RfY0WJrG7WMCXum/rcvNjYhS3DmOfKf8o/Bt56vA3J3yeU0vbgrmltYVoTAfaA==",
+			"version": "1.393.0",
+			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.393.0.tgz",
+			"integrity": "sha512-vzWeEJZ7ERQhFRoQYaP5jzN1JvIu46UJyHXsuv+dTGW2r3sMgREOhNxXLZjmFHwZ8/FOHQoyqqQmXTCXZSfMSg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@protobufjs/aspromise": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/base64": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/codegen": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/eventemitter": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/fetch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.1",
-				"@protobufjs/inquire": "^1.1.0"
-			}
-		},
-		"node_modules/@protobufjs/float": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-			"integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/path": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/pool": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/utf8": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-			"dev": true,
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/@publint/pack": {
 			"version": "0.1.4",
@@ -2035,16 +1699,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/node": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.1.tgz",
-			"integrity": "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"undici-types": "~7.16.0"
-			}
-		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -2338,9 +1992,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2521,9 +2175,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.48.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
-			"integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+			"integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -3675,13 +3329,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/long": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-			"dev": true,
-			"license": "Apache-2.0"
-		},
 		"node_modules/lz-string": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -4034,9 +3681,9 @@
 			}
 		},
 		"node_modules/postcss-load-config/node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+			"integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
@@ -4119,36 +3766,39 @@
 			"license": "MIT"
 		},
 		"node_modules/posthog-js": {
-			"version": "1.342.1",
-			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.342.1.tgz",
-			"integrity": "sha512-mMnQhWuKj4ejFicLtFzr52InmqploOyW1eInqXBkaVqE1DPhczBDmwsd9MSggY8kv0EXm8zgK+2tzBJUKcX5yg==",
+			"version": "1.399.1",
+			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.399.1.tgz",
+			"integrity": "sha512-xuDe1ZnWgpW0vPs9lvEEWeyMSookjkjUYzdNsMmdbVaBuiRm/bVLvuN72mezqNBf07P+Rjg+5FkNif3VysRL6g==",
 			"dev": true,
-			"license": "SEE LICENSE IN LICENSE",
+			"license": "(Apache-2.0 AND MIT)",
 			"dependencies": {
-				"@opentelemetry/api": "^1.9.0",
-				"@opentelemetry/api-logs": "^0.208.0",
-				"@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
-				"@opentelemetry/resources": "^2.2.0",
-				"@opentelemetry/sdk-logs": "^0.208.0",
-				"@posthog/core": "1.20.1",
-				"@posthog/types": "1.342.1",
-				"core-js": "^3.38.1",
-				"dompurify": "^3.3.1",
+				"@posthog/core": "^1.40.1",
+				"@posthog/types": "^1.393.0",
+				"core-js": "^3.49.0",
+				"dompurify": "^3.3.2",
 				"fflate": "^0.4.8",
-				"preact": "^10.28.2",
+				"preact": "^10.29.3",
 				"query-selector-shadow-dom": "^1.0.1",
-				"web-vitals": "^5.1.0"
+				"web-vitals": "^5.3.0"
 			}
 		},
 		"node_modules/preact": {
-			"version": "10.28.3",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.28.3.tgz",
-			"integrity": "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==",
+			"version": "10.29.7",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+			"integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/preact"
+			},
+			"peerDependencies": {
+				"preact-render-to-string": ">=5"
+			},
+			"peerDependenciesMeta": {
+				"preact-render-to-string": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/prelude-ls": {
@@ -4265,31 +3915,6 @@
 				"prettier-plugin-svelte": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/protobufjs": {
-			"version": "7.5.8",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
-			"integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.2",
-				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.5",
-				"@protobufjs/eventemitter": "^1.1.0",
-				"@protobufjs/fetch": "^1.1.0",
-				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.1",
-				"@protobufjs/path": "^1.1.2",
-				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.1",
-				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/publint": {
@@ -4854,13 +4479,6 @@
 				"node": ">=14.17"
 			}
 		},
-		"node_modules/undici-types": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -5097,9 +4715,9 @@
 			}
 		},
 		"node_modules/web-vitals": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
-			"integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+			"integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},

--- a/package.json
+++ b/package.json
@@ -92,5 +92,10 @@
 	},
 	"overrides": {
 		"cookie": "0.7.0"
+	},
+	"allowScripts": {
+		"esbuild@0.28.1": true,
+		"fsevents@2.3.3": true,
+		"core-js@3.49.0": true
 	}
 }


### PR DESCRIPTION
Cleans up npm audit findings and the new allow-scripts warnings.

Changes:
- `npm audit fix`: removes 30 unused packages, 0 vulnerabilities remain
- add `allowScripts` block to package.json approving esbuild, fsevents, core-js install scripts (all reviewed: platform binary install, native macOS watcher, funding note)
- entries are version-pinned, so a future bump of these packages warns once until re-approved

Validation
- `npm install` runs clean with no allow-scripts warnings
- `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)